### PR TITLE
edited adminui.tsx and check-in/route.ts allowing admins to set window on checking in

### DIFF
--- a/nobedevops/src/app/api/check-in/route.ts
+++ b/nobedevops/src/app/api/check-in/route.ts
@@ -1,6 +1,14 @@
 import { NextResponse } from "next/server";
 import { createClient } from "@/app/utils/supabase/server";
 
+function formatChicagoTime(value: string) {
+  return new Date(value).toLocaleString("en-US", {
+    dateStyle: "medium",
+    timeStyle: "short",
+    timeZone: "America/Chicago",
+  });
+}
+
 export async function POST(req: Request) {
   try {
     const supabase = await createClient();
@@ -29,7 +37,7 @@ export async function POST(req: Request) {
 
     const { data: event, error: eventError } = await supabase
       .from("events")
-      .select("id, name")
+      .select("id, name, check_in_starts_at, check_in_ends_at")
       .eq("qr_code_secret", qr_code_secret)
       .single();
 
@@ -38,6 +46,34 @@ export async function POST(req: Request) {
         { ok: false, message: "Invalid QR code." },
         { status: 404 }
       );
+    }
+
+    const now = new Date();
+
+    if (event.check_in_starts_at) {
+      const startsAt = new Date(event.check_in_starts_at);
+      if (now < startsAt) {
+        return NextResponse.json(
+          {
+            ok: false,
+            message: `Check-in opens at ${formatChicagoTime(event.check_in_starts_at)}.`,
+          },
+          { status: 403 }
+        );
+      }
+    }
+
+    if (event.check_in_ends_at) {
+      const endsAt = new Date(event.check_in_ends_at);
+      if (now > endsAt) {
+        return NextResponse.json(
+          {
+            ok: false,
+            message: `Check-in closed at ${formatChicagoTime(event.check_in_ends_at)}.`,
+          },
+          { status: 403 }
+        );
+      }
     }
 
     const { data: existingAttendance, error: existingError } = await supabase

--- a/nobedevops/src/app/users/admin/adminUI.tsx
+++ b/nobedevops/src/app/users/admin/adminUI.tsx
@@ -10,13 +10,16 @@ const supabase = createClient(
 );
 
 export default function AdminUI() {
-    const PUBLIC_URL = " http://10.192.204.178:3000";
+    const PUBLIC_URL = "http://localhost:3000"; // Change this to your LAN IP adress for testing on phone
     const [form, setForm] = useState({
         name: "",
-        event_type: "PROFESSIONAL",
+        event_type: "PROFESSIONAL", 
         points: 0,
         is_mandatory: false,
         date: "",
+        has_check_in_window: false,
+        check_in_start_offset_minutes: "0",
+        check_in_end_offset_minutes: "30",
         committee_id: "",
         project_id: "",
         created_at: ""
@@ -51,14 +54,42 @@ export default function AdminUI() {
         e.preventDefault();
 
         try {
+            const eventDate = new Date(form.date);
+
+            if (Number.isNaN(eventDate.getTime())) {
+                setMessage("Please enter a valid event date.");
+                setCheckInUrl("");
+                return;
+            }
+
+            const startOffsetMinutes = Number(form.check_in_start_offset_minutes);
+            const endOffsetMinutes = Number(form.check_in_end_offset_minutes);
+
+            if (
+                form.has_check_in_window &&
+                startOffsetMinutes > endOffsetMinutes
+            ) {
+                setMessage("Check-in start must be before check-in end.");
+                setCheckInUrl("");
+                return;
+            }
+
             const secret = await fetchQrSecret();
+            const checkInStartsAt = new Date(eventDate.getTime() + startOffsetMinutes * 60_000);
+            const checkInEndsAt = new Date(eventDate.getTime() + endOffsetMinutes * 60_000);
 
             const payload = {
                 name: form.name,
                 event_type: form.event_type,
                 points: Number(form.points),
                 is_mandatory: Boolean(form.is_mandatory),
-                date: new Date(form.date).toISOString(),
+                date: eventDate.toISOString(),
+                check_in_starts_at: form.has_check_in_window
+                    ? checkInStartsAt.toISOString()
+                    : null,
+                check_in_ends_at: form.has_check_in_window
+                    ? checkInEndsAt.toISOString()
+                    : null,
                 created_at: new Date(form.created_at).toISOString(),
                 qr_code_secret: secret,
             };
@@ -127,6 +158,53 @@ export default function AdminUI() {
                         onChange={change}
                     />
                 </div>
+                <div>
+                    <label>Check-In Window:</label>
+                    <input
+                        type="checkbox"
+                        name="has_check_in_window"
+                        checked={form.has_check_in_window}
+                        onChange={(e) =>
+                            setForm(prev => ({
+                                ...prev,
+                                has_check_in_window: e.target.checked,
+                            }))
+                        }
+                    />
+                </div>
+                {form.has_check_in_window && (
+                    <div
+                        style={{
+                            marginLeft: "20px",
+                            marginTop: "12px",
+                            padding: "12px 16px",
+                            borderLeft: "3px solid #2563eb",
+                            background: "#000000",
+                            color: "#ffffff",
+                        }}
+                    >
+                        <div>
+                            <label>Check-In Starts (negative values allowed):</label><br />
+                            <input
+                                type="number"
+                                name="check_in_start_offset_minutes"
+                                value={form.check_in_start_offset_minutes}
+                                onChange={change}
+                                style={{ color: "#ffffff", background: "#000000" }}
+                            />
+                        </div>
+                        <div style={{ marginTop: "12px" }}>
+                            <label>Check-In Ends:</label><br />
+                            <input
+                                type="number"
+                                name="check_in_end_offset_minutes"
+                                value={form.check_in_end_offset_minutes}
+                                onChange={change}
+                                style={{ color: "#ffffff", background: "#000000" }}
+                            />
+                        </div>
+                    </div>
+                )}
                 <div>
                     <label>Committee ID:</label><br />
                     <input


### PR DESCRIPTION
adminui.tsx changes:
-added code to read check_in_starts_at and check_in_ends_at fields from events. These are two new fields that I created in supabase to help track the check-in window
-added a formatChicagoTime function to help display the timestamp value in chicago time to tell members who scanned in what time the check-in is supposed to be/was if they are before or after the window. 

check-in/route.ts changes:
-added a checkbox to enable time windows on events which prompts the user to enter in how many minutes before the event and how many minutes after the event the size of the time window will be