### PR TITLE
made dashboard for reviewing absence requests, approve or deny, email infra not working

### DIFF
--- a/nobedevops/Dockerfile
+++ b/nobedevops/Dockerfile
@@ -65,6 +65,7 @@ COPY --from=build /app/.next/standalone ./
 
 USER nextjs
 
+
 EXPOSE 3000
 
 # Next standalone server entrypoint:

--- a/nobedevops/src/app/api/admin/review-absence/route.ts
+++ b/nobedevops/src/app/api/admin/review-absence/route.ts
@@ -1,0 +1,208 @@
+import { NextResponse } from "next/server";
+import { createClient as createSupabaseClient } from "@supabase/supabase-js";
+import { createClient } from "@/app/utils/supabase/server";
+
+type ReviewPayload = {
+  absenceId?: string;
+  status?: string;
+  responseMessage?: string;
+};
+
+type ReviewResult = {
+  id: string;
+  status: string | null;
+  admin_response: string | null;
+  reviewed_at: string | null;
+  email_sent: boolean | null;
+  email_error: string | null;
+};
+
+export async function POST(request: Request) {
+  try {
+    const body = (await request.json()) as ReviewPayload;
+    const absenceId = body.absenceId?.trim();
+    const status = body.status?.trim().toUpperCase();
+    const responseMessage = body.responseMessage?.trim();
+
+    if (!absenceId || !status || !responseMessage) {
+      return NextResponse.json(
+        { error: "Missing required fields: absenceId, status, responseMessage." },
+        { status: 400 }
+      );
+    }
+
+    if (status !== "APPROVED" && status !== "DENIED") {
+      return NextResponse.json(
+        { error: "Status must be APPROVED or DENIED." },
+        { status: 400 }
+      );
+    }
+
+    const supabase = await createClient();
+    const {
+      data: { user },
+      error: userError,
+    } = await supabase.auth.getUser();
+
+    if (userError || !user) {
+      return NextResponse.json(
+        { error: "You must be logged in to review absence requests." },
+        { status: 401 }
+      );
+    }
+
+    const { data: absence, error: absenceError } = await supabase
+      .from("excused_absences")
+      .select("id, user_id, reason, status")
+      .eq("id", absenceId)
+      .single();
+
+    if (absenceError || !absence) {
+      return NextResponse.json(
+        { error: "Absence request not found." },
+        { status: 404 }
+      );
+    }
+
+    if (!absence.user_id) {
+      return NextResponse.json(
+        { error: "This absence request is not linked to a user account." },
+        { status: 400 }
+      );
+    }
+
+    const emailStatus = status === "APPROVED" ? "approved" : "disapproved";
+    let emailSent = false;
+    let emailError: string | null = null;
+    let reviewRecipient: string | null = null;
+
+    try {
+      const adminClient = createAdminClient();
+      const { data: authUserData, error: authUserError } =
+        await adminClient.auth.admin.getUserById(absence.user_id);
+
+      if (authUserError || !authUserData.user?.email) {
+        emailError = "The member email could not be resolved from Supabase Auth.";
+      } else {
+        reviewRecipient = authUserData.user.email;
+      }
+    } catch (error: any) {
+      emailError = error?.message || "Supabase admin credentials are not configured.";
+    }
+
+    if (reviewRecipient) {
+      const emailBody = [
+        `Your absence request has been ${emailStatus}.`,
+        "",
+        `Reason submitted: ${absence.reason?.trim() || "No reason provided."}`,
+        "",
+        "Admin response:",
+        responseMessage,
+      ].join("\n");
+
+      const emailResult = await sendEmail({
+        to: reviewRecipient,
+        subject: `Absence request ${emailStatus}`,
+        message: emailBody,
+      });
+
+      emailSent = emailResult.ok;
+      emailError = emailResult.ok ? null : emailResult.error || "Failed to send review email.";
+    }
+
+    const reviewedAt = new Date().toISOString();
+    const { data: updatedReview, error: updateError } = await supabase
+      .from("excused_absences")
+      .update({
+        status,
+        admin_response: responseMessage,
+        reviewed_at: reviewedAt,
+        email_sent: emailSent,
+        email_error: emailError,
+      })
+      .eq("id", absenceId)
+      .select("id, status, admin_response, reviewed_at, email_sent, email_error")
+      .single();
+
+    if (updateError || !updatedReview) {
+      return NextResponse.json(
+        { error: updateError?.message || "Failed to save review." },
+        { status: 500 }
+      );
+    }
+
+    return NextResponse.json({
+      ok: true,
+      emailSent,
+      emailError,
+      review: updatedReview as ReviewResult,
+    });
+  } catch (error: any) {
+    return NextResponse.json(
+      { error: error?.message || "Unexpected server error." },
+      { status: 500 }
+    );
+  }
+}
+
+function createAdminClient() {
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+  if (!url || !serviceRoleKey) {
+    throw new Error("Supabase admin credentials are not configured.");
+  }
+
+  return createSupabaseClient(url, serviceRoleKey, {
+    auth: {
+      autoRefreshToken: false,
+      persistSession: false,
+    },
+  });
+}
+
+async function sendEmail({
+  to,
+  subject,
+  message,
+}: {
+  to: string;
+  subject: string;
+  message: string;
+}) {
+  const resendApiKey = process.env.RESEND_API_KEY;
+
+  if (!resendApiKey) {
+    return { ok: false, error: "Email service not configured." };
+  }
+
+  const response = await fetch("https://api.resend.com/emails", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${resendApiKey}`,
+    },
+    body: JSON.stringify({
+      from: "onboarding@resend.dev",
+      to,
+      subject,
+      html: `<p>${escapeHtml(message).replace(/\n/g, "<br>")}</p>`,
+    }),
+  });
+
+  if (!response.ok) {
+    const errorBody = await response.text();
+    return { ok: false, error: errorBody || "Email send failed." };
+  }
+
+  return { ok: true };
+}
+
+function escapeHtml(value: string) {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}

--- a/nobedevops/src/app/users/admin/reviewAbsence/page.tsx
+++ b/nobedevops/src/app/users/admin/reviewAbsence/page.tsx
@@ -1,9 +1,85 @@
-export default function ReviewAbsence() {
-    return(
-        <div>
-            <button type="button" >
-                ReviewAbsence
-            </button>
-        </div>
-    )
+import { createClient } from "@/app/utils/supabase/server";
+import AdminGuard from "../AdminGuard";
+import ReviewAbsenceClient, { type ReviewAbsenceItem } from "./reviewAbsenceClient";
+
+export const dynamic = "force-dynamic";
+export const revalidate = 0;
+
+type ExcusedAbsenceRow = {
+  id: string;
+  user_id: string | null;
+  reason: string | null;
+  status: string | null;
+  submitted_at: string | null;
+  admin_response: string | null;
+  reviewed_at: string | null;
+  email_sent: boolean | null;
+  email_error: string | null;
+};
+
+type PersonRow = {
+  auth_id: string | null;
+  name: string | null;
+  illinois_email: string | null;
+};
+
+export default async function ReviewAbsence() {
+  const supabase = await createClient();
+
+  const [absencesRes, peopleRes] = await Promise.all([
+    supabase
+      .from("excused_absences")
+      .select("id, user_id, reason, status, submitted_at, admin_response, reviewed_at, email_sent, email_error")
+      .order("submitted_at", { ascending: false }),
+    supabase
+      .from("People")
+      .select("auth_id, name, illinois_email"),
+  ]);
+
+  const error = absencesRes.error ?? peopleRes.error;
+  const absences = (absencesRes.data ?? []) as ExcusedAbsenceRow[];
+  const people = (peopleRes.data ?? []) as PersonRow[];
+  const submitterByAuthId = new Map(
+    people
+      .filter((person) => person.auth_id)
+      .map((person) => [
+        person.auth_id as string,
+        person.name?.trim() || person.illinois_email?.trim() || person.auth_id,
+      ])
+  );
+
+  const items: ReviewAbsenceItem[] = absences.map((absence) => ({
+    id: absence.id,
+    submitterLabel: absence.user_id
+      ? submitterByAuthId.get(absence.user_id) ?? absence.user_id
+      : "N/A",
+    reason: absence.reason,
+    status: absence.status,
+    submittedAt: absence.submitted_at,
+    adminResponse: absence.admin_response,
+    reviewedAt: absence.reviewed_at,
+    emailSent: absence.email_sent,
+    emailError: absence.email_error,
+  }));
+
+  return (
+    <AdminGuard>
+      <main className="mx-auto max-w-6xl p-6 space-y-6">
+        <header className="space-y-1">
+          <h1 className="text-2xl font-semibold">Review Absences</h1>
+          <p className="text-sm opacity-80">
+            Review submitted absence requests, send a response, and update request status.
+          </p>
+        </header>
+
+        {error ? (
+          <section className="rounded-lg border border-red-200 bg-red-50 p-4 text-sm text-red-700">
+            Failed to load absence requests: {error.message}
+          </section>
+        ) : (
+          <ReviewAbsenceClient items={items} />
+        )}
+      </main>
+    </AdminGuard>
+  );
 }

--- a/nobedevops/src/app/users/admin/reviewAbsence/reviewAbsenceClient.tsx
+++ b/nobedevops/src/app/users/admin/reviewAbsence/reviewAbsenceClient.tsx
@@ -1,0 +1,393 @@
+"use client";
+
+import { Children, type ReactNode, useState } from "react";
+
+export type ReviewAbsenceItem = {
+  id: string;
+  submitterLabel: string;
+  reason: string | null;
+  status: string | null;
+  submittedAt: string | null;
+  adminResponse: string | null;
+  reviewedAt: string | null;
+  emailSent: boolean | null;
+  emailError: string | null;
+};
+
+type ReviewFormState = {
+  status: "APPROVED" | "DENIED";
+  responseMessage: string;
+  submitting: boolean;
+  error: string;
+  success: string;
+};
+
+type Props = {
+  items: ReviewAbsenceItem[];
+};
+
+export default function ReviewAbsenceClient({ items }: Props) {
+  const [rows, setRows] = useState(items);
+  const [activeSection, setActiveSection] = useState<"PENDING" | "REVIEWED">("PENDING");
+  const [forms, setForms] = useState<Record<string, ReviewFormState>>(() =>
+    Object.fromEntries(
+      items.map((item) => [
+        item.id,
+        {
+          status: normalizeReviewStatus(item.status),
+          responseMessage: "",
+          submitting: false,
+          error: "",
+          success: "",
+        },
+      ])
+    )
+  );
+
+  function updateForm(id: string, patch: Partial<ReviewFormState>) {
+    setForms((current) => ({
+      ...current,
+      [id]: {
+        ...current[id],
+        ...patch,
+      },
+    }));
+  }
+
+  async function handleSubmit(absenceId: string) {
+    const form = forms[absenceId];
+
+    if (!form) {
+      return;
+    }
+
+    const trimmedMessage = form.responseMessage.trim();
+
+    if (!trimmedMessage) {
+      updateForm(absenceId, {
+        error: "A response message is required before sending the review.",
+        success: "",
+      });
+      return;
+    }
+
+    updateForm(absenceId, {
+      submitting: true,
+      error: "",
+      success: "",
+    });
+
+    try {
+      const response = await fetch("/api/admin/review-absence", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          absenceId,
+          status: form.status,
+          responseMessage: trimmedMessage,
+        }),
+      });
+
+      const payload = await response.json();
+
+      if (!response.ok) {
+        updateForm(absenceId, {
+          submitting: false,
+          error: payload?.error ?? "Failed to submit review.",
+          success: "",
+        });
+        return;
+      }
+
+      setRows((current) =>
+        current.map((row) =>
+          row.id === absenceId
+            ? {
+                ...row,
+                status: payload?.review?.status ?? form.status,
+                adminResponse: payload?.review?.admin_response ?? trimmedMessage,
+                reviewedAt: payload?.review?.reviewed_at ?? new Date().toISOString(),
+                emailSent: payload?.review?.email_sent ?? payload?.emailSent ?? false,
+                emailError: payload?.review?.email_error ?? payload?.emailError ?? null,
+              }
+            : row
+        )
+      );
+      setActiveSection("REVIEWED");
+
+      updateForm(absenceId, {
+        submitting: false,
+        responseMessage: "",
+        error: "",
+        success:
+          payload?.emailSent
+            ? "Review saved and email sent."
+            : "Review saved. Email could not be sent.",
+      });
+    } catch {
+      updateForm(absenceId, {
+        submitting: false,
+        error: "Unexpected network error while submitting the review.",
+        success: "",
+      });
+    }
+  }
+
+  if (rows.length === 0) {
+    return (
+      <section className="rounded-lg border border-black/10 p-6 text-sm opacity-80 dark:border-white/20">
+        No absence requests have been submitted yet.
+      </section>
+    );
+  }
+
+  const pendingRows = rows.filter((row) => normalizeStoredStatus(row.status) === "PENDING");
+  const reviewedRows = rows.filter((row) => normalizeStoredStatus(row.status) !== "PENDING");
+  const visibleRows = activeSection === "PENDING" ? pendingRows : reviewedRows;
+
+  return (
+    <section className="space-y-4">
+      <div className="flex flex-wrap gap-3">
+        <SectionToggle
+          label="Pending"
+          count={pendingRows.length}
+          active={activeSection === "PENDING"}
+          onClick={() => setActiveSection("PENDING")}
+        />
+        <SectionToggle
+          label="Reviewed"
+          count={reviewedRows.length}
+          active={activeSection === "REVIEWED"}
+          onClick={() => setActiveSection("REVIEWED")}
+        />
+      </div>
+
+      {activeSection === "PENDING" ? (
+        <ReviewSection
+          description="Requests awaiting an approval or denial."
+          emptyText="No pending requests right now."
+        >
+          {visibleRows.map((item) => {
+            const form = forms[item.id];
+
+            return (
+              <article
+                key={item.id}
+                className="rounded-xl border border-black/10 p-5 dark:border-white/20"
+              >
+                <div className="flex flex-col gap-3 border-b border-black/10 pb-4 dark:border-white/10 md:flex-row md:items-start md:justify-between">
+                  <div className="space-y-2">
+                    <h2 className="text-lg font-medium">{item.submitterLabel}</h2>
+                    <p className="text-sm opacity-80">
+                      Submitted {formatTimestamp(item.submittedAt)}
+                    </p>
+                    <p className="text-sm">
+                      <span className="font-medium">Current status:</span>{" "}
+                      {item.status ?? "PENDING"}
+                    </p>
+                    <p className="text-sm whitespace-pre-wrap">
+                      <span className="font-medium">Reason:</span>{" "}
+                      {item.reason?.trim() ? item.reason : "No reason provided"}
+                    </p>
+                  </div>
+                </div>
+
+                <div className="mt-4 grid gap-4 lg:grid-cols-[220px_minmax(0,1fr)]">
+                  <label className="space-y-2 text-sm">
+                    <span className="block font-medium">Decision</span>
+                    <select
+                      value={form.status}
+                      disabled={form.submitting}
+                      onChange={(event) =>
+                        updateForm(item.id, {
+                          status: event.target.value as "APPROVED" | "DENIED",
+                        })
+                      }
+                      className="w-full rounded-lg border border-black/15 bg-white px-3 py-2 dark:border-white/20 dark:bg-transparent"
+                    >
+                      <option value="APPROVED">Approved</option>
+                      <option value="DENIED">Disapproved</option>
+                    </select>
+                  </label>
+
+                  <label className="space-y-2 text-sm">
+                    <span className="block font-medium">Response message</span>
+                    <textarea
+                      value={form.responseMessage}
+                      disabled={form.submitting}
+                      onChange={(event) =>
+                        updateForm(item.id, {
+                          responseMessage: event.target.value,
+                        })
+                      }
+                      rows={5}
+                      placeholder="Write the message that should be emailed back to the member."
+                      className="w-full rounded-lg border border-black/15 bg-white px-3 py-2 dark:border-white/20 dark:bg-transparent"
+                    />
+                  </label>
+                </div>
+
+                <div className="mt-4 flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+                  <div className="min-h-5 text-sm">
+                    {form.error ? (
+                      <p className="text-red-600 dark:text-red-300">{form.error}</p>
+                    ) : form.success ? (
+                      <p className="text-green-700 dark:text-green-300">{form.success}</p>
+                    ) : null}
+                  </div>
+
+                  <button
+                    type="button"
+                    disabled={form.submitting}
+                    onClick={() => handleSubmit(item.id)}
+                    className="inline-flex items-center justify-center rounded-lg bg-black px-4 py-2 text-sm font-medium text-white disabled:cursor-not-allowed disabled:opacity-60 dark:bg-white dark:text-black"
+                  >
+                    {form.submitting ? "Submitting..." : "Submit review"}
+                  </button>
+                </div>
+              </article>
+            );
+          })}
+        </ReviewSection>
+      ) : (
+        <ReviewSection
+          description="Completed reviews with the saved response and email outcome."
+          emptyText="No reviewed requests yet."
+        >
+          {visibleRows.map((item) => (
+            <article
+              key={item.id}
+              className="rounded-xl border border-black/10 p-5 dark:border-white/20"
+            >
+              <div className="space-y-2">
+                <h2 className="text-lg font-medium">{item.submitterLabel}</h2>
+                <p className="text-sm opacity-80">
+                  Submitted {formatTimestamp(item.submittedAt)}
+                </p>
+                <p className="text-sm">
+                  <span className="font-medium">Decision:</span>{" "}
+                  {item.status ?? "N/A"}
+                </p>
+                <p className="text-sm whitespace-pre-wrap">
+                  <span className="font-medium">Reason:</span>{" "}
+                  {item.reason?.trim() ? item.reason : "No reason provided"}
+                </p>
+                <p className="text-sm whitespace-pre-wrap">
+                  <span className="font-medium">Response message:</span>{" "}
+                  {item.adminResponse?.trim() ? item.adminResponse : "No response saved"}
+                </p>
+                <p className="text-sm">
+                  <span className="font-medium">Reviewed at:</span>{" "}
+                  {formatTimestamp(item.reviewedAt)}
+                </p>
+                <p className="text-sm">
+                  <span className="font-medium">Email status:</span>{" "}
+                  {item.emailSent
+                    ? "Sent"
+                    : item.emailError?.trim()
+                      ? `Not sent - ${item.emailError}`
+                      : "Not sent"}
+                </p>
+              </div>
+            </article>
+          ))}
+        </ReviewSection>
+      )}
+    </section>
+  );
+}
+
+function normalizeReviewStatus(status: string | null): "APPROVED" | "DENIED" {
+  return status?.trim().toUpperCase() === "DENIED" ? "DENIED" : "APPROVED";
+}
+
+function normalizeStoredStatus(status: string | null) {
+  const normalized = status?.trim().toUpperCase();
+
+  if (normalized === "APPROVED" || normalized === "DENIED") {
+    return normalized;
+  }
+
+  return "PENDING";
+}
+
+function ReviewSection({
+  description,
+  emptyText,
+  children,
+}: {
+  description: string;
+  emptyText: string;
+  children: ReactNode;
+}) {
+  const items = Children.toArray(children);
+
+  return (
+    <section className="space-y-4 rounded-2xl border border-black/10 p-5 dark:border-white/20">
+      <p className="text-sm opacity-80">{description}</p>
+
+      {items.length > 0 ? items : (
+        <div className="rounded-lg border border-dashed border-black/15 p-4 text-sm opacity-80 dark:border-white/20">
+          {emptyText}
+        </div>
+      )}
+    </section>
+  );
+}
+
+function SectionToggle({
+  label,
+  count,
+  active,
+  onClick,
+}: {
+  label: string;
+  count: number;
+  active: boolean;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={`inline-flex items-center gap-2 rounded-full border px-4 py-2 text-sm font-medium transition ${
+        active
+          ? "border-black bg-black text-white dark:border-white dark:bg-white dark:text-black"
+          : "border-black/15 bg-white text-black dark:border-white/20 dark:bg-transparent dark:text-white"
+      }`}
+    >
+      <span>{label}</span>
+      <span
+        className={`rounded-full px-2 py-0.5 text-xs ${
+          active
+            ? "bg-white/15 text-white dark:bg-black/10 dark:text-black"
+            : "bg-black/5 text-black dark:bg-white/10 dark:text-white"
+        }`}
+      >
+        {count}
+      </span>
+    </button>
+  );
+}
+
+function formatTimestamp(value: string | null) {
+  if (!value) {
+    return "N/A";
+  }
+
+  const date = new Date(value);
+
+  if (Number.isNaN(date.getTime())) {
+    return value;
+  }
+
+  return new Intl.DateTimeFormat("en-US", {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+  }).format(date);
+}


### PR DESCRIPTION
Admins can now view absence requests made by members, mark as approved or denied, submit a message. An attempt is made to email the user who made the request by getting the email from the auth.users table, but the current way I'm going about it, using Resend, I can only send emails to myself but the code is there for when we come up with a better strategy for sending automated emails. It currently works fine on absence requests made with my email. 


