### PR TITLE
created two way sync logic betwn gcal and web

### DIFF
--- a/nobedevops/src/app/api/gcal-club/create-event/route.ts
+++ b/nobedevops/src/app/api/gcal-club/create-event/route.ts
@@ -1,0 +1,51 @@
+import { google } from 'googleapis';
+import { NextRequest, NextResponse } from 'next/server';
+
+const CLUB_CALENDAR_ID =
+  'f4953a68bd3b75e409d7490b65356747c22af1e3fc89b177d6bad1b93a88e097@group.calendar.google.com';
+
+export async function POST(req: NextRequest) {
+  try {
+    const { event } = await req.json();
+
+    const oauth2Client = new google.auth.OAuth2(
+      process.env.GOOGLE_CLIENT_ID,
+      process.env.GOOGLE_CLIENT_SECRET,
+      process.env.GOOGLE_REDIRECT_URI
+    );
+
+    oauth2Client.setCredentials({
+      refresh_token: process.env.GOOGLE_REFRESH_TOKEN,
+    });
+
+    const calendar = google.calendar({ version: 'v3', auth: oauth2Client });
+
+    const start = new Date(event.date);
+    const end = event.end_date ? new Date(event.end_date) : new Date(start.getTime() + 60 * 60 * 1000);
+
+    // Embed the NOBE event type in the description so it can be parsed on import
+    const descriptionLines = [
+      `Type: ${event.event_type}`,
+      `Points: ${event.points}`,
+      event.dresscode ? `Dress Code: ${event.dresscode}` : null,
+      event.is_mandatory ? 'Mandatory: Yes' : null,
+    ].filter(Boolean);
+
+    const result = await calendar.events.insert({
+      calendarId: CLUB_CALENDAR_ID,
+      requestBody: {
+        summary: event.name,
+        location: event.location || '',
+        description: descriptionLines.join('\n'),
+        start: { dateTime: start.toISOString() },
+        end: { dateTime: end.toISOString() },
+      },
+    });
+
+    return NextResponse.json({ success: true, googleEventId: result.data.id });
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : 'Unknown error';
+    console.error('Error creating GCal club event:', message);
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}

--- a/nobedevops/src/app/api/gcal-club/events/route.ts
+++ b/nobedevops/src/app/api/gcal-club/events/route.ts
@@ -2,7 +2,7 @@ import { google } from 'googleapis';
 import { NextResponse } from 'next/server';
 
 const CLUB_CALENDAR_ID =
-  'c_2487c0bc3a9c7383b716813d0f8531e5b9d356d83754436bc837acece9b6f1ee@group.calendar.google.com';
+  'f4953a68bd3b75e409d7490b65356747c22af1e3fc89b177d6bad1b93a88e097@group.calendar.google.com';
 
 export async function GET() {
   try {
@@ -30,19 +30,26 @@ export async function GET() {
     });
 
     const events =
-      result.data.items?.map((event) => ({
-        id: `gcal-${event.id}`,
-        name: event.summary || 'Untitled Event',
-        event_type: 'GCAL_CLUB',
-        date: event.start?.dateTime || event.start?.date || new Date().toISOString(),
-        end_date: event.end?.dateTime || event.end?.date || null,
-        points: null,
-        is_mandatory: null,
-        qr_code_secret: null,
-        created_at: event.created || new Date().toISOString(),
-        location: event.location || null,
-        description: event.description || null,
-      })) || [];
+      result.data.items?.map((event) => {
+        const description = event.description || null;
+        // Parse event type embedded by the webapp when pushing to GCal
+        const nobeTypeMatch = description?.match(/Type:\s*(.+)/);
+        const eventType = nobeTypeMatch ? nobeTypeMatch[1].trim() : 'GCAL_UNSPECIFIED';
+
+        return {
+          id: `gcal-${event.id}`,
+          name: event.summary || 'Untitled Event',
+          event_type: eventType,
+          date: event.start?.dateTime || event.start?.date || new Date().toISOString(),
+          end_date: event.end?.dateTime || event.end?.date || null,
+          points: null,
+          is_mandatory: null,
+          qr_code_secret: null,
+          created_at: event.created || new Date().toISOString(),
+          location: event.location || null,
+          description,
+        };
+      }) || [];
 
     return NextResponse.json({ events });
   } catch (err: unknown) {

--- a/nobedevops/src/app/api/gcal-club/sync/route.ts
+++ b/nobedevops/src/app/api/gcal-club/sync/route.ts
@@ -1,0 +1,101 @@
+import { google } from 'googleapis';
+import { NextResponse } from 'next/server';
+import { createClient } from '@supabase/supabase-js';
+
+const CLUB_CALENDAR_ID =
+  'f4953a68bd3b75e409d7490b65356747c22af1e3fc89b177d6bad1b93a88e097@group.calendar.google.com';
+
+function parseDescription(description: string | null) {
+  const nobeTypeMatch = description?.match(/Type:\s*(.+)/);
+  const pointsMatch = description?.match(/Points:\s*(\d+)/);
+  const dresscodeMatch = description?.match(/Dress Code:\s*(.+)/);
+  const mandatoryMatch = description?.match(/Mandatory:\s*Yes/i);
+
+  return {
+    event_type: nobeTypeMatch ? nobeTypeMatch[1].trim() : 'GCAL_UNSPECIFIED',
+    points: pointsMatch ? parseInt(pointsMatch[1], 10) : 0,
+    dresscode: dresscodeMatch ? dresscodeMatch[1].trim() : null,
+    is_mandatory: !!mandatoryMatch,
+  };
+}
+
+export async function POST() {
+  try {
+    const oauth2Client = new google.auth.OAuth2(
+      process.env.GOOGLE_CLIENT_ID,
+      process.env.GOOGLE_CLIENT_SECRET,
+      process.env.GOOGLE_REDIRECT_URI
+    );
+
+    oauth2Client.setCredentials({
+      refresh_token: process.env.GOOGLE_REFRESH_TOKEN,
+    });
+
+    const calendar = google.calendar({ version: 'v3', auth: oauth2Client });
+
+    const oneYearAgo = new Date();
+    oneYearAgo.setFullYear(oneYearAgo.getFullYear() - 1);
+
+    const result = await calendar.events.list({
+      calendarId: CLUB_CALENDAR_ID,
+      timeMin: oneYearAgo.toISOString(),
+      maxResults: 250,
+      singleEvents: true,
+      orderBy: 'startTime',
+    });
+
+    const gcalItems = result.data.items || [];
+
+    // Use service role key to bypass RLS for server-side sync
+    const supabase = createClient(
+      process.env.NEXT_PUBLIC_SUPABASE_URL!,
+      process.env.SUPABASE_SERVICE_ROLE_KEY!
+    );
+
+    // Upsert each GCal event into Supabase
+    for (const event of gcalItems) {
+      if (!event.id) continue;
+
+      const parsed = parseDescription(event.description || null);
+
+      const { error } = await supabase.from('events').upsert(
+        {
+          gcal_event_id: event.id,
+          name: event.summary || 'Untitled Event',
+          event_type: parsed.event_type,
+          date: event.start?.dateTime || event.start?.date || new Date().toISOString(),
+          location: event.location || null,
+          points: parsed.points,
+          dresscode: parsed.dresscode,
+          is_mandatory: parsed.is_mandatory,
+        },
+        { onConflict: 'gcal_event_id' }
+      );
+
+      if (error) {
+        console.error(`Failed to upsert GCal event ${event.id}:`, error.message);
+      }
+    }
+
+    // Delete Supabase events whose GCal event no longer exists
+    const gcalIds = gcalItems.map((e) => e.id).filter(Boolean) as string[];
+
+    const { data: stale } = await supabase
+      .from('events')
+      .select('id, gcal_event_id')
+      .not('gcal_event_id', 'is', null);
+
+    if (stale) {
+      const toDelete = stale.filter((e) => !gcalIds.includes(e.gcal_event_id));
+      for (const e of toDelete) {
+        await supabase.from('events').delete().eq('id', e.id);
+      }
+    }
+
+    return NextResponse.json({ success: true, synced: gcalItems.length });
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : 'Unknown error';
+    console.error('GCal sync error:', message);
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}

--- a/nobedevops/src/app/users/admin/createEvent/page.tsx
+++ b/nobedevops/src/app/users/admin/createEvent/page.tsx
@@ -277,18 +277,54 @@ export default function CreateEventPage() {
         qr_code_secret: secret,
       };
 
-      const { error } = eventId
-        ? await supabase.from("events").update(payload).eq("id", eventId)
-        : await supabase.from("events").insert(payload);
+      let newEventId: string | null = null;
+      if (eventId) {
+        const { error } = await supabase.from("events").update(payload).eq("id", eventId);
+        if (error) { setMessage(error.message); return; }
+      } else {
+        const { data: inserted, error } = await supabase.from("events").insert(payload).select("id").single();
+        if (error) { setMessage(error.message); return; }
+        newEventId = inserted?.id ?? null;
+      }
 
-      if (error) {
-        setMessage(error.message);
-        return;
+      // Push new events to the NOBE Google Calendar (skip on update to avoid duplicates)
+      let gcalWarning = "";
+      if (!eventId) {
+        try {
+          const gcalRes = await fetch("/api/gcal-club/create-event", {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({
+              event: {
+                name: payload.name,
+                event_type: payload.event_type,
+                date: payload.date,
+                end_date: checkInEndsAt.toISOString(),
+                location: payload.location,
+                points: payload.points,
+                dresscode: payload.dresscode,
+                is_mandatory: payload.is_mandatory,
+              },
+            }),
+          });
+          const gcalData = await gcalRes.json().catch(() => ({}));
+          if (!gcalRes.ok) {
+            gcalWarning = ` (Google Calendar sync failed: ${gcalData.error ?? gcalRes.statusText})`;
+          } else if (gcalData.googleEventId && newEventId) {
+            await supabase.from("events").update({ gcal_event_id: gcalData.googleEventId }).eq("id", newEventId);
+          }
+        } catch (gcalErr: any) {
+          gcalWarning = ` (Google Calendar sync failed: ${gcalErr?.message ?? "network error"})`;
+        }
       }
 
       const url = `${window.location.origin}/check-in/${secret}`;
       setQrLink(url);
-      setMessage(eventId ? "Event updated successfully." : "Event created successfully.");
+      setMessage(
+        eventId
+          ? "Event updated successfully."
+          : `Event created successfully.${gcalWarning}`
+      );
     } catch (err: any) {
       setMessage(err?.message ?? "Unable to create event.");
     } finally {

--- a/nobedevops/src/app/users/admin/viewAllEvents/page.tsx
+++ b/nobedevops/src/app/users/admin/viewAllEvents/page.tsx
@@ -14,10 +14,10 @@ type EventItem = {
   dresscode?: string;
   is_mandatory: boolean | null;
   created_at: string;
-  // Google Calendar fields
   location?: string | null;
   description?: string | null;
   end_date?: string | null;
+  gcal_event_id?: string | null;
 };
 
 type EventStats = {
@@ -34,12 +34,11 @@ const supabase = createClient(
 );
 
 function isGcalEvent(event: EventItem) {
-  return event.event_type === "GCAL_CLUB";
+  return !!event.gcal_event_id && !event.qr_code_secret;
 }
 
 export default function ViewAllEvents() {
   const [events, setEvents] = useState<EventItem[]>([]);
-  const [gcalEvents, setGcalEvents] = useState<EventItem[]>([]);
   const [search, setSearch] = useState("");
   const [loading, setLoading] = useState(true);
   const [gcalLoading, setGcalLoading] = useState(true);
@@ -59,43 +58,41 @@ export default function ViewAllEvents() {
     setMounted(true);
   }, []);
 
-  useEffect(() => {
-    async function fetchEvents() {
-      setLoading(true);
-      setError("");
-      const { data, error } = await supabase
-        .from("events")
-        .select("id, name, points, date, qr_code_secret, event_type, dresscode, is_mandatory, created_at")
-        .order("date", { ascending: true });
-      if (error) {
-        setError(error.message);
-      } else {
-        setEvents((data as EventItem[]) || []);
-      }
-      setLoading(false);
+  async function fetchEvents() {
+    setLoading(true);
+    setError("");
+    const { data, error } = await supabase
+      .from("events")
+      .select("id, name, points, date, qr_code_secret, event_type, dresscode, is_mandatory, created_at, gcal_event_id")
+      .order("date", { ascending: true });
+    if (error) {
+      setError(error.message);
+    } else {
+      setEvents((data as EventItem[]) || []);
     }
-    fetchEvents();
-  }, []);
+    setLoading(false);
+  }
 
-  async function fetchGcalEvents() {
+  async function syncAndRefetch() {
     setGcalLoading(true);
     setGcalError("");
     try {
-      const res = await fetch("/api/gcal-club/events");
+      const res = await fetch("/api/gcal-club/sync", { method: "POST" });
       const json = await res.json();
       if (json.error) {
         setGcalError(json.error);
       } else {
-        setGcalEvents(json.events || []);
+        await fetchEvents();
       }
     } catch {
-      setGcalError("Failed to load Google Calendar events.");
+      setGcalError("Failed to sync Google Calendar events.");
     }
     setGcalLoading(false);
   }
 
   useEffect(() => {
-    fetchGcalEvents();
+    fetchEvents();
+    syncAndRefetch();
   }, []);
 
   useEffect(() => {
@@ -137,7 +134,7 @@ export default function ViewAllEvents() {
     fetchEventStats();
   }, [selectedEvent]);
 
-  const allEvents = useMemo(() => [...events, ...gcalEvents], [events, gcalEvents]);
+  const allEvents = useMemo(() => events, [events]);
 
   const filteredEvents = useMemo(() => {
     return allEvents.filter((event) => {
@@ -289,7 +286,7 @@ export default function ViewAllEvents() {
                   <option value="NEW_MEMBER_WORKSHOP">New Member Workshop</option>
                   <option value="PROJECT_MEETING">Project Meeting</option>
                   <option value="OTHER_MANDATORY">Other Mandatory</option>
-                  <option value="GCAL_CLUB">Google Calendar</option>
+                  <option value="GCAL_UNSPECIFIED">Google Calendar</option>
                 </select>
               </div>
               <div className="field-group">
@@ -419,7 +416,7 @@ export default function ViewAllEvents() {
               </p>
               <button
                 type="button"
-                onClick={fetchGcalEvents}
+                onClick={syncAndRefetch}
                 disabled={gcalLoading}
                 className="btn-secondary"
                 style={{ fontSize: "0.75rem", padding: "4px 10px" }}
@@ -565,7 +562,7 @@ export default function ViewAllEvents() {
                           <div className="panel-header" style={{ marginBottom: "10px" }}>
                             <strong>{event.name}</strong>
                             <span className="calendar-event-chip">
-                              {isGcalEvent(event) ? "Google Calendar" : event.is_mandatory ? "Mandatory" : "Optional"}
+                              {event.is_mandatory ? "Mandatory" : isGcalEvent(event) ? "Unspecified" : "Optional"}
                             </span>
                           </div>
                           <p className="section-copy">{formatDate(event.date)}</p>

--- a/nobedevops/src/app/users/member/eventList.tsx
+++ b/nobedevops/src/app/users/member/eventList.tsx
@@ -99,9 +99,19 @@ export default function EventList() {
 
         if (fetchError) throw fetchError;
         setNobeEvents(data || []);
+        setLoading(false);
+
+        // Sync club GCal in background, then refresh events with latest data
+        fetch('/api/gcal-club/sync', { method: 'POST' })
+          .then(() =>
+            supabase.from('events').select('*').order('date', { ascending: false })
+          )
+          .then(({ data: fresh }) => {
+            if (fresh) setNobeEvents(fresh);
+          })
+          .catch(() => {});
       } catch (err) {
         setError(err instanceof Error ? err.message : 'Failed to fetch events');
-      } finally {
         setLoading(false);
       }
     };


### PR DESCRIPTION
  New files:                                                                    
  - api/gcal-club/sync/route.ts — syncs club GCal to Supabase via upsert on
  gcal_event_id, deletes removed events                                         
  - api/gcal-club/create-event/route.ts — pushes new NOBE events to GCal (before it didn't update) 
                                                                                
  Modified files:
  - api/gcal-club/events/route.ts — changed calendar ID, updated type parser    
  from [NOBE_TYPE:...] to Type: ..., default changed to GCAL_UNSPECIFIED        
  - api/gcal-club/create-event/route.ts — changed calendar ID, updated embedded
  description format from [NOBE_TYPE:...] to Type: ...                          
  - users/admin/createEvent/page.tsx — after inserting event, saves returned    
  gcal_event_id back to Supabase row                                        
  - users/admin/viewAllEvents/page.tsx — removed separate GCal overlay, replaced
   with sync call on load + "Sync GCal" button calls new sync endpoint,         
  isGcalEvent now checks gcal_event_id, badge changed to "Unspecified" for      
  unspecified GCal events                                                       
  - users/member/eventList.tsx — triggers sync in background on load, refetches 
  Supabase events after sync completes