### PR TITLE
fleshed out user sign up feature

### DIFF
--- a/nobedevops/next.config.ts
+++ b/nobedevops/next.config.ts
@@ -2,9 +2,6 @@ import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
   output: "standalone",
-  turbopack: {
-    root: __dirname,
-  },
 };
 
 export default nextConfig;

--- a/nobedevops/src/app/api/auth/update-signup-profile/route.ts
+++ b/nobedevops/src/app/api/auth/update-signup-profile/route.ts
@@ -1,0 +1,27 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { createAdminClient } from '@/app/utils/supabase/admin';
+
+export async function POST(req: NextRequest) {
+  const { auth_id, first_name, last_name, illinois_email } = await req.json();
+
+  if (!auth_id || !first_name || !last_name || !illinois_email) {
+    return NextResponse.json({ error: 'Missing required fields.' }, { status: 400 });
+  }
+
+  const supabase = createAdminClient();
+  const { error } = await supabase
+    .from('People')
+    .update({
+      first_name,
+      last_name,
+      name: `${first_name} ${last_name}`,
+      illinois_email,
+    })
+    .eq('auth_id', auth_id);
+
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+
+  return NextResponse.json({ ok: true });
+}

--- a/nobedevops/src/app/auth/callback/route.ts
+++ b/nobedevops/src/app/auth/callback/route.ts
@@ -9,8 +9,8 @@ export async function GET(req: NextRequest) {
   const type = searchParams.get('type') as 'email' | 'recovery' | 'invite' | null;
   const next = searchParams.get('next');
 
-  // Never auto-verify on GET — email scanners pre-fetch links and burn one-time tokens.
-  // Forward to pages that require a real user click before calling verifyOtp.
+  // Don't auto-verify invite/email links on GET — email scanners can pre-fetch links and burn one-time tokens.
+  // Redirect to pages that require a real user click before calling verifyOtp.
   if (token_hash && type === 'invite') {
     return NextResponse.redirect(
       `${origin}/auth/setup-account?token_hash=${token_hash}&type=${type}`

--- a/nobedevops/src/app/auth/callback/route.ts
+++ b/nobedevops/src/app/auth/callback/route.ts
@@ -9,11 +9,17 @@ export async function GET(req: NextRequest) {
   const type = searchParams.get('type') as 'email' | 'recovery' | 'invite' | null;
   const next = searchParams.get('next');
 
-  // Invite links must NOT be auto-verified on GET (email scanners will burn the token).
-  // Forward to a page that requires a real click before calling verifyOtp.
+  // Never auto-verify on GET — email scanners pre-fetch links and burn one-time tokens.
+  // Forward to pages that require a real user click before calling verifyOtp.
   if (token_hash && type === 'invite') {
     return NextResponse.redirect(
       `${origin}/auth/setup-account?token_hash=${token_hash}&type=${type}`
+    );
+  }
+
+  if (token_hash && type === 'email') {
+    return NextResponse.redirect(
+      `${origin}/auth/confirm-email?token_hash=${token_hash}&type=${type}`
     );
   }
 

--- a/nobedevops/src/app/auth/confirm-email/page.tsx
+++ b/nobedevops/src/app/auth/confirm-email/page.tsx
@@ -1,0 +1,98 @@
+"use client";
+
+import { useState, useEffect, Suspense } from "react";
+import { useSearchParams, useRouter } from "next/navigation";
+import { createClient } from "@/app/utils/supabase/client";
+
+function ConfirmEmailInner() {
+  const searchParams = useSearchParams();
+  const router = useRouter();
+  const supabase = createClient();
+
+  const tokenHash = searchParams.get("token_hash");
+  const type = searchParams.get("type");
+
+  const [stage, setStage] = useState<"ready" | "confirming" | "done" | "error">("ready");
+  const [errorMsg, setErrorMsg] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!tokenHash || !type) {
+      setStage("error");
+      setErrorMsg("This confirmation link is missing required information.");
+    }
+  }, [tokenHash, type]);
+
+  async function handleConfirm() {
+    if (!tokenHash || !type) return;
+    setStage("confirming");
+
+    const { error } = await supabase.auth.verifyOtp({
+      token_hash: tokenHash,
+      type: type as any,
+    });
+
+    if (error) {
+      setStage("error");
+      setErrorMsg("This confirmation link has expired or is invalid. Please sign up again to get a new one.");
+      return;
+    }
+
+    setStage("done");
+    setTimeout(() => router.push("/users/login?confirmed=1"), 1500);
+  }
+
+  return (
+    <div className="auth-shell">
+      <div className="auth-card">
+        <img
+          src="/nobe_logo_f.svg"
+          alt="NOBE Illinois"
+          className="brand-logo brand-logo-header"
+          style={{ width: '120px', height: '120px' }}
+        />
+        <h1 className="page-title" style={{ fontSize: "2rem", textAlign: "center", marginBottom: "8px" }}>
+          Confirm your email
+        </h1>
+
+        {stage === "ready" && (
+          <div style={{ display: "flex", flexDirection: "column", gap: "16px", marginTop: "8px" }}>
+            <p className="page-subtitle" style={{ textAlign: "center" }}>
+              Click below to confirm your NOBE Illinois account.
+            </p>
+            <button onClick={handleConfirm} className="btn button-full">
+              Confirm my email
+            </button>
+          </div>
+        )}
+
+        {stage === "confirming" && (
+          <p className="page-subtitle" style={{ textAlign: "center", marginTop: "16px" }}>
+            Confirming...
+          </p>
+        )}
+
+        {stage === "done" && (
+          <p className="page-subtitle" style={{ textAlign: "center", marginTop: "16px" }}>
+            Email confirmed! Redirecting you to sign in...
+          </p>
+        )}
+
+        {stage === "error" && (
+          <div style={{ marginTop: "16px" }}>
+            <div className="message-error" style={{ textAlign: "center" }}>
+              {errorMsg}
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export default function ConfirmEmailPage() {
+  return (
+    <Suspense>
+      <ConfirmEmailInner />
+    </Suspense>
+  );
+}

--- a/nobedevops/src/app/users/login/login.tsx
+++ b/nobedevops/src/app/users/login/login.tsx
@@ -15,17 +15,40 @@ export default function LoginForm() {
     searchParams.get('redirect') || searchParams.get('next');
 
   const [mode, setMode] = useState<'signin' | 'signup' | 'forgot'>('signin');
-  const [name, setName] = useState('');
+  const [firstName, setFirstName] = useState('');
+  const [lastName, setLastName] = useState('');
   const [testingMode, setTestingMode] = useState(false);
   const [email, setEmail] = useState('');
+  const [confirmEmail, setConfirmEmail] = useState('');
   const [password, setPassword] = useState('');
   const [error, setError] = useState<string | null>(
     searchParams.get('error') === 'link_expired'
-      ? 'That link has expired. Please request a new one.'
+      ? 'That confirmation link has expired. Please sign up again to get a new one.'
       : null
   );
-  const [message, setMessage] = useState<string | null>(null);
+  const [message, setMessage] = useState<string | null>(
+    searchParams.get('confirmed') === '1' ? 'Email confirmed! You can now sign in.' : null
+  );
   const [submitting, setSubmitting] = useState(false);
+  const [showPassword, setShowPassword] = useState(false);
+  const [showResend, setShowResend] = useState(false);
+  const [resending, setResending] = useState(false);
+
+  // Parse Supabase error params from URL hash (e.g. otp_expired after clicking email link)
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    const hash = window.location.hash;
+    if (!hash) return;
+    const params = new URLSearchParams(hash.slice(1));
+    const errorCode = params.get('error_code');
+    const errorDescription = params.get('error_description');
+    if (errorCode === 'otp_expired') {
+      setError('Your email confirmation link has expired. Please sign up again to receive a new one.');
+    } else if (errorCode) {
+      setError(errorDescription ?? 'Something went wrong. Please try again.');
+    }
+    window.history.replaceState(null, '', window.location.pathname + window.location.search);
+  }, []);
 
   useEffect(() => {
     if (!loading && profile) {
@@ -55,6 +78,27 @@ export default function LoginForm() {
     setMode(next);
     setError(null);
     setMessage(null);
+    setShowResend(false);
+    setConfirmEmail('');
+  }
+
+  async function handleResend() {
+    setResending(true);
+    const { error } = await supabase.auth.resend({
+      type: 'signup',
+      email,
+      options: {
+        emailRedirectTo: `${window.location.origin}/auth/callback`,
+      },
+    });
+    setResending(false);
+    if (error) {
+      setError(error.message);
+    } else {
+      setShowResend(false);
+      setError(null);
+      setMessage('Confirmation email resent! Check your inbox.');
+    }
   }
 
   async function handleSubmit(e: React.SyntheticEvent) {
@@ -71,23 +115,51 @@ export default function LoginForm() {
 
     if (mode === 'signin') {
       const { error } = await supabase.auth.signInWithPassword({ email, password });
-      if (error) setError(error.message);
+      if (error) {
+        setError(error.message);
+        if (error.message === 'Email not confirmed') setShowResend(true);
+      }
       // redirect handled by useEffect once profile loads
     } else if (mode === 'signup') {
-      const { error } = await supabase.auth.signUp({
+      if (email !== confirmEmail) {
+        setError('Email addresses do not match.');
+        setSubmitting(false);
+        return;
+      }
+      const { data, error } = await supabase.auth.signUp({
         email,
         password,
         options: {
           data: {
-            full_name: name,
+            first_name: firstName,
+            last_name: lastName,
+            full_name: `${firstName} ${lastName}`,
           },
         },
       });
       if (error) {
         setError(error.message);
-      } else {
-        setMessage('Sign up successful! Please check your email or log in.');
-        setMode('signin');
+      } else if (data.user?.identities?.length === 0) {
+        setError('An account with this email already exists. Please sign in instead.');
+        setShowResend(true);
+      } else if (data.user) {
+        const res = await fetch('/api/auth/update-signup-profile', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            auth_id: data.user.id,
+            first_name: firstName,
+            last_name: lastName,
+            illinois_email: email,
+          }),
+        });
+        if (!res.ok) {
+          const body = await res.json();
+          setError(`Account created but profile setup failed: ${body.error ?? 'unknown error'}. Please contact an admin.`);
+        } else {
+          setMessage('Sign up successful! Check your email to confirm your account.');
+          setMode('signin');
+        }
       }
     } else {
       const { error } = await supabase.auth.resetPasswordForEmail(email, {
@@ -137,7 +209,20 @@ export default function LoginForm() {
         </div>
 
         {error && (
-          <div className="message-error" style={{ marginTop: '20px' }}>{error}</div>
+          <div style={{ marginTop: '20px' }}>
+            <div className="message-error">{error}</div>
+            {showResend && (
+              <button
+                type="button"
+                onClick={handleResend}
+                disabled={resending}
+                className="btn button-full"
+                style={{ marginTop: '8px' }}
+              >
+                {resending ? 'Resending...' : 'Resend confirmation email'}
+              </button>
+            )}
+          </div>
         )}
         {message && (
           <div className="message-success" style={{ marginTop: '20px' }}>{message}</div>
@@ -145,15 +230,27 @@ export default function LoginForm() {
 
         <form onSubmit={handleSubmit} className="field-group" style={{ marginTop: '20px' }}>
           {mode === 'signup' && (
-            <div className="field-group">
-              <label className="field-label">Full name</label>
-              <input
-                type="text"
-                value={name}
-                onChange={e => setName(e.target.value)}
-                required
-                className="field-input"
-              />
+            <div style={{ display: 'flex', gap: '12px' }}>
+              <div className="field-group" style={{ flex: 1 }}>
+                <label className="field-label">First name</label>
+                <input
+                  type="text"
+                  value={firstName}
+                  onChange={e => setFirstName(e.target.value)}
+                  required
+                  className="field-input"
+                />
+              </div>
+              <div className="field-group" style={{ flex: 1 }}>
+                <label className="field-label">Last name</label>
+                <input
+                  type="text"
+                  value={lastName}
+                  onChange={e => setLastName(e.target.value)}
+                  required
+                  className="field-input"
+                />
+              </div>
             </div>
           )}
 
@@ -169,15 +266,39 @@ export default function LoginForm() {
             />
           </div>
 
+          {mode === 'signup' && (
+            <div className="field-group">
+              <label className="field-label">Confirm email</label>
+              <input
+                type="email"
+                value={confirmEmail}
+                onChange={e => setConfirmEmail(e.target.value)}
+                placeholder="netid@illinois.edu"
+                required
+                className="field-input"
+              />
+            </div>
+          )}
+
           <div className="field-group">
             <label className="field-label">Password</label>
-            <input
-              type="password"
-              value={password}
-              onChange={e => setPassword(e.target.value)}
-              required
-              className="field-input"
-            />
+            <div style={{ position: 'relative' }}>
+              <input
+                type={showPassword ? 'text' : 'password'}
+                value={password}
+                onChange={e => setPassword(e.target.value)}
+                required
+                className="field-input"
+                style={{ paddingRight: '60px' }}
+              />
+              <button
+                type="button"
+                onClick={() => setShowPassword(v => !v)}
+                style={{ position: 'absolute', right: '10px', top: '50%', transform: 'translateY(-50%)', background: 'none', border: 'none', cursor: 'pointer', fontSize: '0.8rem', color: 'var(--muted)', padding: '0' }}
+              >
+                {showPassword ? 'Hide' : 'Show'}
+              </button>
+            </div>
           </div>
 
           <label style={{ display: 'flex', alignItems: 'center', gap: '8px', fontSize: '0.8rem', color: 'var(--muted)', cursor: 'pointer', marginTop: '4px' }}>
@@ -196,30 +317,11 @@ export default function LoginForm() {
             style={{ marginTop: '8px' }}
           >
             {submitting
-              ? mode === 'signin' ? 'Signing in...' : 'Sending...'
-              : mode === 'signin' ? 'Sign in' : 'Send reset link'}
+              ? mode === 'signin' ? 'Signing in...' : mode === 'signup' ? 'Creating account...' : 'Sending...'
+              : mode === 'signin' ? 'Sign in' : mode === 'signup' ? 'Create account' : 'Send reset link'}
           </button>
         </form>
 
-        <div className="text-center text-sm">
-          {mode === 'signin' ? (
-            <button
-              type="button"
-              onClick={() => switchMode('forgot')}
-              className="text-blue-600 hover:underline"
-            >
-              Forgot password?
-            </button>
-          ) : (
-            <button
-              type="button"
-              onClick={() => switchMode('signin')}
-              className="text-blue-600 hover:underline"
-            >
-              Back to sign in
-            </button>
-          )}
-        </div>
       </div>
     </div>
   );

--- a/nobedevops/src/app/users/member/actions.ts
+++ b/nobedevops/src/app/users/member/actions.ts
@@ -2,6 +2,40 @@
 
 import { createClient } from "@/app/utils/supabase/server";
 
+export async function updateMemberProfile({
+  first_name,
+  last_name,
+  year,
+  college,
+  major,
+}: {
+  first_name: string;
+  last_name: string;
+  year: string;
+  college: string;
+  major: string;
+}) {
+  const supabase = await createClient();
+  const { data: { user }, error: userError } = await supabase.auth.getUser();
+  if (userError || !user) return { error: 'Not authenticated.' };
+
+  const { error } = await supabase
+    .from('People')
+    .update({
+      first_name,
+      last_name,
+      name: `${first_name} ${last_name}`,
+      year,
+      college,
+      major,
+      illinois_email: user.email,
+    })
+    .eq('auth_id', user.id);
+
+  if (error) return { error: error.message };
+  return { error: null };
+}
+
 export async function getMemberStrikes() {
   const supabase = await createClient();
 

--- a/nobedevops/src/app/users/member/eventList.tsx
+++ b/nobedevops/src/app/users/member/eventList.tsx
@@ -5,7 +5,7 @@ import { usePathname } from 'next/navigation';
 import { useEffect, useMemo, useState } from 'react';
 import { createClient } from '@supabase/supabase-js';
 import { useAuth } from '../authprovider';
-import { getMemberStrikes } from './actions';
+import { getMemberStrikes, updateMemberProfile } from './actions';
 import LogoutButton from '../login/logout';
 
 interface Event {
@@ -47,8 +47,11 @@ const EVENT_TYPES = Object.keys(EVENT_TYPE_CONFIG);
 
 interface MemberProfile {
   name: string | null;
+  first_name: string | null;
+  last_name: string | null;
   year: string | null;
   college: string | null;
+  major: string | null;
   committee: string | null;
   social_points: number | null;
   professional_points: number | null;
@@ -74,6 +77,11 @@ export default function EventList() {
   const [mounted, setMounted] = useState(false);
   const [strikes, setStrikes] = useState<Strike[]>([]);
   const [viewMode, setViewMode] = useState<"CALENDAR" | "LIST">("CALENDAR");
+  const [editingProfile, setEditingProfile] = useState(false);
+  const [profileForm, setProfileForm] = useState({ first_name: '', last_name: '', year: '', college: '', major: '' });
+  const [profileSaving, setProfileSaving] = useState(false);
+  const [profileError, setProfileError] = useState<string | null>(null);
+  const [profileSuccess, setProfileSuccess] = useState(false);
 
 
   useEffect(() => {
@@ -151,7 +159,7 @@ export default function EventList() {
       const { data, error: fetchError } = await supabase
         .from('People')
         .select(
-          'name, year, college, committee, social_points, professional_points, service_points, strikes, auth_id'
+          'name, first_name, last_name, year, college, major, committee, social_points, professional_points, service_points, strikes, auth_id'
         )
         .eq('auth_id', session.user.id)
         .single();
@@ -162,6 +170,13 @@ export default function EventList() {
         setStrikes([]);
       } else {
         setMember(data as MemberProfile);
+        setProfileForm({
+          first_name: data.first_name ?? '',
+          last_name: data.last_name ?? '',
+          year: data.year ?? '',
+          college: data.college ?? '',
+          major: data.major ?? '',
+        });
 
         try {
           const strikeData = await getMemberStrikes();
@@ -436,6 +451,10 @@ export default function EventList() {
 
                 <div className="subtle-card list-stack">
                   <div className="metric-pair">
+                    <span>Email</span>
+                    <span>{session?.user?.email || 'N/A'}</span>
+                  </div>
+                  <div className="metric-pair">
                     <span>Year</span>
                     <span>{member.year || 'N/A'}</span>
                   </div>
@@ -444,10 +463,83 @@ export default function EventList() {
                     <span>{member.college || 'N/A'}</span>
                   </div>
                   <div className="metric-pair">
+                    <span>Major</span>
+                    <span>{member.major || 'N/A'}</span>
+                  </div>
+                  <div className="metric-pair">
                     <span>Committee</span>
                     <span>{member.committee || 'N/A'}</span>
                   </div>
                 </div>
+
+                <button
+                  type="button"
+                  className="btn-secondary"
+                  style={{ width: '100%' }}
+                  onClick={() => { setEditingProfile(v => !v); setProfileError(null); setProfileSuccess(false); }}
+                >
+                  {editingProfile ? 'Cancel' : 'Edit profile'}
+                </button>
+
+                {editingProfile && (
+                  <form
+                    className="field-group"
+                    onSubmit={async (e) => {
+                      e.preventDefault();
+                      setProfileSaving(true);
+                      setProfileError(null);
+                      setProfileSuccess(false);
+                      const { error } = await updateMemberProfile(profileForm);
+                      setProfileSaving(false);
+                      if (error) {
+                        setProfileError(error);
+                      } else {
+                        setProfileSuccess(true);
+                        setEditingProfile(false);
+                        setMember(prev => prev ? {
+                          ...prev,
+                          first_name: profileForm.first_name,
+                          last_name: profileForm.last_name,
+                          name: `${profileForm.first_name} ${profileForm.last_name}`,
+                          year: profileForm.year,
+                          college: profileForm.college,
+                          major: profileForm.major,
+                        } : prev);
+                      }
+                    }}
+                  >
+                    <div style={{ display: 'flex', gap: '8px' }}>
+                      <div className="field-group" style={{ flex: 1 }}>
+                        <label className="field-label">First name</label>
+                        <input className="field-input" value={profileForm.first_name} onChange={e => setProfileForm(f => ({ ...f, first_name: e.target.value }))} required />
+                      </div>
+                      <div className="field-group" style={{ flex: 1 }}>
+                        <label className="field-label">Last name</label>
+                        <input className="field-input" value={profileForm.last_name} onChange={e => setProfileForm(f => ({ ...f, last_name: e.target.value }))} required />
+                      </div>
+                    </div>
+                    <div className="field-group">
+                      <label className="field-label">Year</label>
+                      <input className="field-input" value={profileForm.year} onChange={e => setProfileForm(f => ({ ...f, year: e.target.value }))} placeholder="e.g. Junior" />
+                    </div>
+                    <div className="field-group">
+                      <label className="field-label">College</label>
+                      <input className="field-input" value={profileForm.college} onChange={e => setProfileForm(f => ({ ...f, college: e.target.value }))} placeholder="e.g. Grainger" />
+                    </div>
+                    <div className="field-group">
+                      <label className="field-label">Major</label>
+                      <input className="field-input" value={profileForm.major} onChange={e => setProfileForm(f => ({ ...f, major: e.target.value }))} placeholder="e.g. Computer Science" />
+                    </div>
+                    {profileError && <div className="message-error">{profileError}</div>}
+                    <button type="submit" className="btn button-full" disabled={profileSaving}>
+                      {profileSaving ? 'Saving...' : 'Save changes'}
+                    </button>
+                  </form>
+                )}
+
+                {profileSuccess && (
+                  <div className="message-success">Profile updated!</div>
+                )}
               </div>
             ) : (
               <div className="message-error">


### PR DESCRIPTION
Features:
-Fixed bug signing up with already existing email
-Allowed Members to edit their own info on member page
-Added a "Resend Confirmation Email" button in case confirmation was missed
-If confirmation fails, it displays that on the page rather than the page just looking normal
-Populates first_name, last_name, and illinois_email fields in the People table in supabase based on created account immediately 
-Fixed bug where the email was being set as the name in the name column for a user, instead of the first name and last name appended together being set as the name. Right now it's only fixed bc the code overrides supabase's mistake but still need to find out why it's bugged on supabase in the first place. 
-If a person in the People table has their illinois_email blank, the website automatically uses their auth id to find their email in the users table under auth and inserts that email into that blank field upon member saving profile changes. 

Issues:
Right now, I disabled email confirmation for testing purposes, so accounts are auto confirmed with no email confirmation right now. The reason I had to turn it off is because supabase can only send 2 emails per hour and I also believe there might be some issue with the confirmation token being burnt right away due to email security scanners but I wasn't able to test this bc of supabase bottleneck. Also, I tried using resend smtp on supabase but I think we need a custom domain if we want to send more than 2 emails / hour through supabase.